### PR TITLE
reboot after kernel upgrade does not reprovision

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ $ make test
 ```
 $ make
 rake build
-vagrant-tun 0.0.2 built to pkg/vagrant-tun-0.0.2.gem.
+vagrant-tun 0.0.3 built to pkg/vagrant-tun-0.0.3.gem.
 ```
 
 ### Install the built gemfile
 ```
 $ make install
 find pkg/ -name '*.gem' | head -n 1 | xargs vagrant plugin install
-Installing the 'pkg/vagrant-tun-0.0.2.gem' plugin. This can take a few minutes...
-Installed the plugin 'vagrant-tun (0.0.2)'!
+Installing the 'pkg/vagrant-tun-0.0.3.gem' plugin. This can take a few minutes...
+Installed the plugin 'vagrant-tun (0.0.3)'!
 ```

--- a/lib/vagrant-tun/command.rb
+++ b/lib/vagrant-tun/command.rb
@@ -81,7 +81,7 @@ module VagrantTun
 
     def reboot(env)
       env[:ui].info("Rebooting because we couldn't load the tun module. Maybe the kernel was updated?")
-      env[:machine].action(:reload)
+      env[:machine].action(:reload, :provision_enabled => false)
       begin
         sleep 1
       end until env[:machine].communicate.ready?

--- a/lib/vagrant-tun/version.rb
+++ b/lib/vagrant-tun/version.rb
@@ -1,5 +1,5 @@
 module Vagrant
   module Tun 
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
so the plugin works with non-idempotent provisioners
